### PR TITLE
fix #121 by creating a specific update view, handling the serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.1] - 2026-XX-XX
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- PATCH of video config was not working. Fixed.
+### Security
+
+
 ## [0.3.0] - 2026-04-03
 ### Added
 ### Changed

--- a/api/serializers/video_config.py
+++ b/api/serializers/video_config.py
@@ -26,7 +26,7 @@ class VideoConfigSerializer(serializers.ModelSerializer):
             user = self.instance.creator
         if user is None:
             user = self.context["request"].user
-
+            
         site = attrs.get("site")
         # validate if site is compliant with user permissions
         institute_validator(institute=site.institute, user=user)
@@ -57,7 +57,7 @@ class VideoConfigCreateSerializer(VideoConfigSerializer):
 class VideoConfigUpdateSerializer(VideoConfigSerializer):
     class Meta: # (VideoConfigSerializer.Meta):
         model = VideoConfig
-        exclude = ("site", "creator")
+        exclude = ("creator",)
 
     def validate(self, attrs):
         return super().validate(attrs)

--- a/api/views/video_config.py
+++ b/api/views/video_config.py
@@ -47,6 +47,25 @@ class VideoConfigViewSet(BaseModelViewSet):
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
+
+    def update(self, request, site_pk=None, *args, **kwargs):
+        """Override update to prevent site and creator from being updated, even if included in request body."""
+        partial = kwargs.pop("partial", False)
+        instance = self.get_object()
+        data = request.data.copy()
+        if not data.get("site"):
+            data["site"] = int(site_pk)
+        if not data.get("creator"):
+            data["creator"] = instance.creator.pk
+        data["creator"] = instance.creator.pk
+
+        kwargs.setdefault("context", self.get_serializer_context())
+        serializer = self.get_serializer(instance, data=data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        # headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data) #, status=status.HTTP_200_OK, headers=headers)
+    
     # TODO: once orc-os api is connected, bring back task generation in a new approach with celery agents.
     # @extend_schema(
     #     description="Create a task form for a specified device based on this video configuration",


### PR DESCRIPTION
## Issue addressed
Fixes #121 - PATCH on VideoConfig not working

## Explanation
Made sure the `site` is available during validation of PATCH data so that the request and access rights can be properly validated.

## General Checklist
- [x] Updated tests or added new tests
- [x] Fork is up-to-date with `main`
- [x] Tests pass
- [x] Updated documentation
- [x] Updated changelog.rst
